### PR TITLE
Adds saveMode param to the authenticate endpoint

### DIFF
--- a/module-code/app/securesocial/core/SecureSocial.scala
+++ b/module-code/app/securesocial/core/SecureSocial.scala
@@ -171,6 +171,7 @@ trait SecureSocial extends Controller with I18nSupport {
 
 object SecureSocial {
   val OriginalUrlKey = "original-url"
+  val SaveModeKey = "save-mode"
 
   /**
    * A request that adds the User for the current call

--- a/module-code/app/securesocial/core/services/UserService.scala
+++ b/module-code/app/securesocial/core/services/UserService.scala
@@ -127,4 +127,10 @@ object SaveMode {
   val LoggedIn = SaveMode("loggedIn")
   val SignUp = SaveMode("signUp")
   val PasswordChange = SaveMode("passwordChange")
+
+  private val values = List(LoggedIn, SignUp, PasswordChange)
+
+  def getFromString(str: String): Option[SaveMode] = {
+    values.filter(_.name == str).headOption
+  }
 }

--- a/module-code/app/securesocial/core/utils.scala
+++ b/module-code/app/securesocial/core/utils.scala
@@ -33,7 +33,7 @@ object utils {
     def startingAuthenticator[A](authenticator: Authenticator[A]) = authenticator.starting(r)
     def discardingAuthenticator[A](authenticator: Authenticator[A]) = authenticator.discarding(r)
     def touchingAuthenticator[A](authenticator: Authenticator[A]) = authenticator.touching(r)
-    def addToSession(values: (String, String)*) = {
+    def addToSession(values: (String, String)*): Result = {
       val cookies = Cookies.fromCookieHeader(r.header.headers.get(HeaderNames.SET_COOKIE))
       val resultSession = Session.decodeFromCookie(cookies.get(Session.COOKIE_NAME))
       def addValues(list: List[(String, String)], session: Session): Session = {

--- a/module-code/conf/securesocial.routes
+++ b/module-code/conf/securesocial.routes
@@ -20,8 +20,8 @@ POST        /password                          @securesocial.controllers.Passwor
 
 
 # Authentication entry points for all providers
-GET         /authenticate/:provider        @securesocial.controllers.ProviderController.authenticate(provider, redirectTo: Option[String] ?= None, scope: Option[String] ?= None, miscParam: Option[String] ?= None)
-POST        /authenticate/:provider        @securesocial.controllers.ProviderController.authenticateByPost(provider, redirectTo: Option[String], scope: Option[String], miscParam: Option[String] ?= None)
+GET         /authenticate/:provider        @securesocial.controllers.ProviderController.authenticate(provider, redirectTo: Option[String] ?= None, scope: Option[String] ?= None, saveMode: Option[String] ?= None, miscParam: Option[String] ?= None)
+POST        /authenticate/:provider        @securesocial.controllers.ProviderController.authenticateByPost(provider, redirectTo: Option[String], scope: Option[String], saveMode: Option[String], miscParam: Option[String] ?= None)
 
 POST        /api/authenticate/:provider        @securesocial.controllers.LoginApi.authenticate(provider, builder = "token")
 


### PR DESCRIPTION
This PR adds an optional parameter `saveMode` to `ProviderController.authenticate` and `ProviderController.authenticateByPost` endpoints so the user program can override the value used in `UserService`.