### PR TITLE
Enable to specify authorizationUrlParams

### DIFF
--- a/module-code/app/securesocial/controllers/Implicits.scala
+++ b/module-code/app/securesocial/controllers/Implicits.scala
@@ -1,0 +1,26 @@
+package securesocial.controllers
+
+import play.api.mvc.QueryStringBindable
+
+object Implicits {
+  implicit def queryStringMapBindable(implicit stringBinder: QueryStringBindable[String]) = new QueryStringBindable[Map[String, String]] {
+    def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, Map[String, String]]] = {
+      val regex = s"^$key\\[(\\w+)\\]$$".r // e.g. matches "foo[bar]"
+      Some(Right(params.flatMap {
+        case (paramKey, values) =>
+          paramKey match {
+            case regex(mapKey) =>
+              Some(mapKey -> values.head)
+            case _ => None
+          }
+      }))
+    }
+
+    def unbind(key: String, value: Map[String, String]): String = {
+      value.toList.map {
+        case (mapKey, mapValue) =>
+          stringBinder.unbind(s"${key}[${mapKey}]", mapValue)
+      }.mkString("&")
+    }
+  }
+}

--- a/module-code/app/securesocial/controllers/ProviderController.scala
+++ b/module-code/app/securesocial/controllers/ProviderController.scala
@@ -46,6 +46,11 @@ trait BaseProviderController extends SecureSocial {
    * The authentication entry point for GET requests
    *
    * @param provider The id of the provider that needs to handle the call
+   * @param redirectTo
+   * @param scope This will replace the one defined in securesocial.conf
+   * @param authorizationUrlParams These params will be added to the ones defined in securesocial.conf
+   * @param saveMode One of SaveMode.*
+   * @param miscParam
    */
   def authenticate(provider: String, redirectTo: Option[String] = None, scope: Option[String] = None, authorizationUrlParams: Map[String, String], saveMode: Option[String], miscParam: Option[String]) = {
     handleAuth(provider, redirectTo, scope, authorizationUrlParams, saveMode, miscParam)
@@ -55,6 +60,11 @@ trait BaseProviderController extends SecureSocial {
    * The authentication entry point for POST requests
    *
    * @param provider The id of the provider that needs to handle the call
+   * @param redirectTo
+   * @param scope This will replace the one defined in securesocial.conf
+   * @param authorizationUrlParams These params will be added to the ones defined in securesocial.conf
+   * @param saveMode One of SaveMode.*
+   * @param miscParam
    */
   def authenticateByPost(provider: String, redirectTo: Option[String] = None, scope: Option[String] = None, authorizationUrlParams: Map[String, String], saveMode: Option[String], miscParam: Option[String]) = {
     handleAuth(provider, redirectTo, scope, authorizationUrlParams, saveMode, miscParam)
@@ -89,6 +99,8 @@ trait BaseProviderController extends SecureSocial {
   /**
    * @param provider e.g. "github"
    * @param scope Pass Some[String] to ask for different scopes from those in securesocial.conf
+   * @param authorizationUrlParams
+   * @param saveMode One of SaveMode.*
    * @param miscParam
    */
   private def getProvider(provider: String, scope: Option[String], authorizationUrlParams: Map[String, String], saveMode: Option[String], miscParam: Option[String]): Option[IdentityProvider] = provider match {
@@ -117,6 +129,7 @@ trait BaseProviderController extends SecureSocial {
    * @param provider the provider that needs to handle the flow
    * @param redirectTo the url the user needs to be redirected to after being authenticated
    * @param scope OAuth2 scope
+   * @param authorizationUrlParams
    * @param saveModeStr
    * @param miscParam miscellaneous information necessary for providers
    */

--- a/module-code/build.sbt
+++ b/module-code/build.sbt
@@ -83,3 +83,4 @@ javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-encoding", "UTF-8",  
 
 // packagedArtifacts += ((artifact in playPackageAssets).value -> playPackageAssets.value)
 
+routesImport += "securesocial.controllers.Implicits._"

--- a/module-code/conf/securesocial.routes
+++ b/module-code/conf/securesocial.routes
@@ -20,8 +20,8 @@ POST        /password                          @securesocial.controllers.Passwor
 
 
 # Authentication entry points for all providers
-GET         /authenticate/:provider        @securesocial.controllers.ProviderController.authenticate(provider, redirectTo: Option[String] ?= None, scope: Option[String] ?= None, saveMode: Option[String] ?= None, miscParam: Option[String] ?= None)
-POST        /authenticate/:provider        @securesocial.controllers.ProviderController.authenticateByPost(provider, redirectTo: Option[String], scope: Option[String], saveMode: Option[String], miscParam: Option[String] ?= None)
+GET         /authenticate/:provider        @securesocial.controllers.ProviderController.authenticate(provider, redirectTo: Option[String] ?= None, scope: Option[String] ?= None, authorizationUrlParams: Map[String, String] ?= Map(), saveMode: Option[String] ?= None, miscParam: Option[String] ?= None)
+POST        /authenticate/:provider        @securesocial.controllers.ProviderController.authenticateByPost(provider, redirectTo: Option[String], scope: Option[String], authorizationUrlParams: Map[String, String] ?= Map(), saveMode: Option[String], miscParam: Option[String] ?= None)
 
 POST        /api/authenticate/:provider        @securesocial.controllers.LoginApi.authenticate(provider, builder = "token")
 


### PR DESCRIPTION
Sometimes we want to use `authorizationUrlParams` different from the one defined in `securesocial.conf`, and this PR enables it.